### PR TITLE
Add data team as sql code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.sql       @inventa-shop/schema-owners


### PR DESCRIPTION
This is a test to validate if by adding this config we can have the data team as schema owners for all PRs that contain sql files